### PR TITLE
Fix a bug on windows

### DIFF
--- a/src/SourceBundler.js
+++ b/src/SourceBundler.js
@@ -61,7 +61,7 @@ export default class SourceBundler {
        */
       const relPath = path.join(
         basePath.split(this.rootDir)[1], stats.name,
-      ).replace(/^\/|\/$/g, '');
+      ).replace(/^\/|\/$|^\\|\\$/g, '');
 
       const filePath = path.join(basePath, stats.name);
 


### PR DESCRIPTION
On windows, folders was not included in the bundle.

Can you please include these changes and update dependency of the project "serverless-plugin-elastic-beanstalk".

Please :) Thank you

